### PR TITLE
New ods table format compatibility

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,10 @@ func scrap() (err error) {
 	}
 	sort.Strings(names)
 
-	lastName := names[len(names)-1]
+	lastName := ""
+	if len(names) > 0 {
+		lastName = names[len(names)-1]
+	}
 
 	nextName, err := fetchCurrentName()
 	if err != nil {
@@ -70,6 +73,15 @@ func scrap() (err error) {
 	if !ok {
 		log.Printf("No report yet: %s", nextName)
 		return nil
+	}
+
+	if lastName == "" {
+		lastName = nextName
+
+		err = os.WriteFile("reports/vaccination/"+lastName, nextContents, 0644)
+		if err != nil {
+			return fmt.Errorf("creating %s: %w", lastName, err)
+		}
 	}
 
 	lastContents, err := fs.ReadFile(dir, lastName)

--- a/main.go
+++ b/main.go
@@ -75,18 +75,14 @@ func scrap() (err error) {
 		return nil
 	}
 
+	var lastContents []byte
 	if lastName == "" {
-		lastName = nextName
-
-		err = os.WriteFile("reports/vaccination/"+lastName, nextContents, 0644)
+		lastContents = nextContents
+	} else {
+		lastContents, err = fs.ReadFile(dir, lastName)
 		if err != nil {
-			return fmt.Errorf("creating %s: %w", lastName, err)
+			return fmt.Errorf("reading last report: %w", err)
 		}
-	}
-
-	lastContents, err := fs.ReadFile(dir, lastName)
-	if err != nil {
-		return fmt.Errorf("reading last report: %w", err)
 	}
 
 	baseCfg := extractConfig{
@@ -198,19 +194,34 @@ func (cfg extractConfig) extractReport(doc *ods.Doc, report *vaccReport) error {
 		totalTable := doc.Table[0].Strings()
 
 		header := totalTable[0]
-		assert(header[8] == "Nº Personas con al menos 1 dosis")
-		assert(header[9] == "Nº Personas vacunadas\n(pauta completada)")
-		assert(header[5] == "Total Dosis entregadas (1)")
-		assert(header[6] == "Dosis administradas (2)")
-
 		totals := totalTable[cfg.totalRow]
 		assert(totals[0] == "Totales")
 
-		report.TotalVacced.Single = parseInt(totals[8])
-		report.TotalVacced.Full = parseInt(totals[9])
+		for index, currentTitle := range header {
+			if currentTitle == "Nº Personas con al menos 1 dosis" {
+				report.TotalVacced.Single = parseInt(totals[index])
+				continue
+			}
 
-		report.Doses.Available = parseInt(totals[5])
-		report.Doses.Given = parseInt(totals[6])
+			if currentTitle == "Nº Personas vacunadas\n(pauta completada)" {
+				report.TotalVacced.Full = parseInt(totals[index])
+				continue
+			}
+
+			if currentTitle == "Total Dosis entregadas (1)" {
+				report.Doses.Available = parseInt(totals[index])
+				continue
+			}
+
+			if currentTitle == "Dosis administradas (2)" {
+				report.Doses.Given = parseInt(totals[index])
+			}
+		}
+
+		assert(report.TotalVacced.Single > 0)
+		assert(report.TotalVacced.Full > 0)
+		assert(report.Doses.Available > 0)
+		assert(report.Doses.Given > 0)
 	}
 
 	tableOffset := 0


### PR DESCRIPTION
Update extract report with new ods format, they added a new column with pediatric data since 2021-12-20 https://www.mscbs.gob.es/profesionales/saludPublica/ccayes/alertasActual/nCov/documentos/Informe_Comunicacion_20211220.ods

### Before:

```
$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.16 go build -v && ./es-covid-notify
go: downloading github.com/dghubble/go-twitter v0.0.0-20201011215211-4b180d0cc78d
go: downloading golang.org/x/text v0.3.6
go: downloading github.com/dghubble/oauth1 v0.7.0
go: downloading github.com/knieriem/odf v0.1.0
go: downloading github.com/dghubble/sling v1.3.0
go: downloading github.com/cenkalti/backoff v2.1.1+incompatible
go: downloading github.com/google/go-querystring v1.0.0
golang.org/x/text/internal/tag
golang.org/x/text/internal/stringset
github.com/cenkalti/backoff
github.com/google/go-querystring/query
github.com/knieriem/odf
golang.org/x/text/internal/language
github.com/dghubble/oauth1
github.com/knieriem/odf/ods
github.com/dghubble/sling
github.com/dghubble/go-twitter/twitter
golang.org/x/text/internal/language/compact
golang.org/x/text/language
golang.org/x/text/internal
golang.org/x/text/internal/catmsg
golang.org/x/text/internal/format
golang.org/x/text/internal/number
golang.org/x/text/message/catalog
golang.org/x/text/feature/plural
golang.org/x/text/number
golang.org/x/text/message
panic: assertion failed at /usr/src/myapp/main.go:189

goroutine 1 [running]:
main.assert(0xc0001aa000)
        /usr/src/myapp/main.go:535 +0x106
main.extractConfig.extractReport(0x16, 0xc000631940, 0xc0003343c0, 0x0, 0x0)
        /usr/src/myapp/main.go:189 +0xb5
main.scrap(0x407ce5, 0xc0000181d8)
        /usr/src/myapp/main.go:102 +0x6a9
main.main()
        /usr/src/myapp/main.go:40 +0x26
```

### After:

```
$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.16 go build -v && ./es-covid-notify
go: downloading golang.org/x/text v0.3.6
go: downloading github.com/dghubble/oauth1 v0.7.0
go: downloading github.com/knieriem/odf v0.1.0
go: downloading github.com/dghubble/go-twitter v0.0.0-20201011215211-4b180d0cc78d
go: downloading github.com/dghubble/sling v1.3.0
go: downloading github.com/cenkalti/backoff v2.1.1+incompatible
go: downloading github.com/google/go-querystring v1.0.0
golang.org/x/text/internal/tag
golang.org/x/text/internal/stringset
github.com/cenkalti/backoff
github.com/google/go-querystring/query
github.com/knieriem/odf
golang.org/x/text/internal/language
github.com/dghubble/oauth1
github.com/knieriem/odf/ods
github.com/dghubble/sling
github.com/dghubble/go-twitter/twitter
golang.org/x/text/internal/language/compact
golang.org/x/text/language
golang.org/x/text/internal/catmsg
golang.org/x/text/internal
golang.org/x/text/internal/format
golang.org/x/text/internal/number
golang.org/x/text/message/catalog
golang.org/x/text/feature/plural
golang.org/x/text/number
golang.org/x/text/message
2021/12/27 22:21:45 Handling update: Informe_Comunicacion_20211227.ods
telegram: ------
<pre>▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒░░░░</pre>
<strong>💉💉 79,8 % | 💉 83,3 %</strong>

Dosis puestas: <strong>+2,9 M</strong> | Total: 85,444 M


<strong>💉💉 Pauta completa</strong>
<strong>+75,4 k</strong> (+0,2 % pob.)
Total: <strong>37,853 M</strong> (79,8 % pob.)

<strong>💉 Al menos una dosis</strong>
<strong>+904 k</strong> (+1,9 % pob.)
Total: <strong>39,512 M</strong> (83,3 % pob.)


% por grupos de edad (💉💉 completa / 💉 al menos una dosis):

<pre>≥80   ▓▓▓▓▓▓▓              (102,8 % / 104 %)</pre>
<pre>70-79 ▓▓▓▓▓▓▓▓▓▓           (99,3 % / 100 %)</pre>
<pre>60-69 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓       (97,5 % / 99,6 %)</pre>
<pre>50-59 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░   (94,6 % / 95,8 %)</pre>
<pre>40-49 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░ (88 % / 89,7 %)</pre>
<pre>30-39 ▓▓▓▓▓▓▓▓▓▓▓▓▓░░░     (78,4 % / 81,1 %)</pre>
<pre>20-29 ▓▓▓▓▓▓▓▓▓▓▒░░        (80,4 % / 84,1 %)</pre>
<pre>12-19 ▓▓▓▓▓▓▓▓▓░           (86,1 % / 89,6 %)</pre>

Informe completo disponible en <a href="https://www.mscbs.gob.es/profesionales/saludPublica/ccayes/alertasActual/nCov/vacunaCovid19.htm">la web del Ministerio de Sanidad</a>.

------
tweet: ------
▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒░░░
💉💉 79,8 % | 💉 83,3 %

Puestas: +2,9 M | Total: 85,444 M

💉💉 Pauta completa
+75,4 k (+0,2 % pob.)
Total: 37,853 M (79,8 % pob.)

💉 Al menos una dosis
+904 k (+1,9 % pob.)
Total: 39,512 M (83,3 % pob.)
------
tweet: ------
Por edad (💉💉/💉 %):

▓▓▓▓▓▓▓▓▓▓ ≥80 103/104
▓▓▓▓▓▓▓▓▓▓ 7x 99/100
▓▓▓▓▓▓▓▓▓▓ 6x 98/100
▓▓▓▓▓▓▓▓▓▒ 5x 95/96
▓▓▓▓▓▓▓▓▓░ 4x 88/90
▓▓▓▓▓▓▓▓░░ 3x 78/81
▓▓▓▓▓▓▓▓░░ 2x 80/84
▓▓▓▓▓▓▓▓▓░ 12-19 86/90

------
2021/12/27 22:21:45 Update handled: Informe_Comunicacion_20211227.ods
```